### PR TITLE
feat: createUser mutation

### DIFF
--- a/src/graphql/resolvers.ts
+++ b/src/graphql/resolvers.ts
@@ -1,0 +1,49 @@
+const messages = [
+  {
+    message: 'Hello World!',
+  },
+  {
+    message: 'First Apollo StandaloneServer!',
+  },
+  {
+    message: 'Welcome Again!',
+  },
+];
+
+const users: UserInput[] = [];
+
+interface UserInput {
+  id: number;
+  name: string;
+  email: string;
+  password: string;
+  birthDate: string;
+}
+
+export const resolvers = {
+  Query: {
+    hello: () => messages[0].message,
+    messages: () => messages,
+    getMessage: (_: unknown, { index }: { index: number }) => messages[index],
+    users: () => users,
+  },
+
+  Mutation: {
+    createUser: (_: unknown, { input }: { input: UserInput }) => {
+      const newUser: UserInput = {
+        id: users.length > 0 ? users[users.length - 1].id + 1 : users.length + 1,
+        name: input.name,
+        email: input.email,
+        password: input.password,
+        birthDate: input.birthDate,
+      };
+      users.push(newUser);
+      return {
+        id: newUser.id,
+        name: newUser.name,
+        email: newUser.email,
+        birthDate: newUser.birthDate,
+      };
+    },
+  },
+};

--- a/src/graphql/type-defs.ts
+++ b/src/graphql/type-defs.ts
@@ -7,7 +7,6 @@ export const typeDefs = `#graphql
     id: ID!
     name: String!
     email: String!
-    password: String!
     birthDate: String!
    }
 

--- a/src/graphql/type-defs.ts
+++ b/src/graphql/type-defs.ts
@@ -1,0 +1,31 @@
+export const typeDefs = `#graphql
+   type Message {
+    message: String
+   }
+
+   type User {
+    id: ID!
+    name: String!
+    email: String!
+    password: String!
+    birthDate: String!
+   }
+
+   input UserInput{
+    name: String!
+    email: String!
+    password: String!
+    birthDate: String!
+   }
+
+   type Mutation{
+    createUser(input: UserInput!): User!
+   }
+
+   type Query {
+    hello: String
+    messages: [Message]
+    getMessage(index: Int!): Message
+    users: [User!]!
+  }
+`;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,38 +1,8 @@
 import { ApolloServer } from '@apollo/server';
 import { startStandaloneServer } from '@apollo/server/standalone';
+import { typeDefs } from './graphql/type-defs.js';
+import { resolvers } from './graphql/resolvers.js';
 const port = 4000;
-
-const typeDefs = `
-   type Message {
-    message: String
-   }
-
-   type Query {
-    hello: String
-    messages: [Message]
-    getMessage(index: Int!): Message
-  }
-`;
-
-const messages = [
-  {
-    message: 'Hello World!',
-  },
-  {
-    message: 'First Apollo StandaloneServer!',
-  },
-  {
-    message: 'Welcome Again!',
-  },
-];
-
-const resolvers = {
-  Query: {
-    hello: () => messages[0].message,
-    messages: () => messages,
-    getMessage: (_, { index }) => messages[index],
-  },
-};
 
 const server = new ApolloServer({
   typeDefs,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,9 +4,11 @@
       "outDir": "dist",
       "lib": ["es2020"],
       "target": "es2020",
-      "module": "esnext",
-      "moduleResolution": "node",
+      "module": "NodeNext", // this rule was changed to make the compilation easier when importing modules on ts files.
+      "moduleResolution": "NodeNext", // this rule was changed to make the compilation easier when importing modules on ts files.
       "esModuleInterop": true,
-      "types": ["node"]
+      "forceConsistentCasingInFileNames": true, // this rule was added to maintain consistency in file names.
+      "types": ["node"],
+      "strict": true // this rule was added to fortify the Type checking of my code.
     }
   }


### PR DESCRIPTION
- Separated grahql resolvers and schemas to their own files on the **./src/graphql/** directory
- Added createUser mutation and the UserInput on the type definitions (grahql schema)
- Added a users array (mocked database, it will be removed later)
- New rules and changes on old rules on **tsconfig.json**